### PR TITLE
Actually, we should use git-ls

### DIFF
--- a/python-pre-commit
+++ b/python-pre-commit
@@ -21,7 +21,7 @@ fi
 pylint --rcfile=git-hooks/pylintrc \
        --output-format=colorized \
        --reports=n \
-       $(find . -name \*.py)
+       $(git ls-files | grep '\.py$')
 # pylint return codes described here:
 #   https://lists.logilab.org/pipermail/python-projects/2009-November/002068.html
 # We only care about fatal messages and errors, the existence of which are

--- a/python-prepare-commit-msg
+++ b/python-prepare-commit-msg
@@ -28,7 +28,7 @@ if [[ -z $(which $COVERAGE) ]]; then
   COVERAGE=python-coverage
 fi
 
-PYTHONFILES=$(find . -name \*.py)
+PYTHONFILES=$(git ls-files | grep '\.py$')
 
 (
   echo 'Test coverage is as follows:'


### PR DESCRIPTION
The problems with dockerfiles and build environments should be solved in
a different way.  We should keep git-ls