### PR TITLE
Adding pylint-mccabe to dependencies, which is required by the pylint

### DIFF
--- a/requirements-python.txt
+++ b/requirements-python.txt
@@ -3,4 +3,5 @@ autopep8
 coveralls
 docformatter
 pylint
+pylint-mccabe
 unify


### PR DESCRIPTION
Couldn't get pylint to run without this.