### PR TITLE
gofmt should use the -s arg to simplify the code

### DIFF
--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -106,11 +106,11 @@ golint and go vet found the following issues:
 ${OUTPUT}
 EOF
       fi
-      FILES="$(git ls-files | grep '\.go$' | xargs gofmt -l)"
+      FILES="$(git ls-files | grep '\.go$' | xargs gofmt -s -l)"
       if [[ -n ${FILES} ]]; then
         for f in ${FILES}; do
           echo "gofmt diff for $f:"
-          gofmt -d "$f"
+          gofmt -s -d "$f"
         done
       fi
     fi


### PR DESCRIPTION
no --simplify exists, so the short arg is the only option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/git-hooks/13)
<!-- Reviewable:end -->
