### PR TITLE
Describe better usage of git-hooks

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# This code is intended to be used as part of a submodule called git-hooks.  It
+# This code is intended to be used as in a directory called git-hooks.  It
 # is a language agnostic tester and linter, and should lint, test, and run
 # coverage for any and all languages you happen to use.
 #
 # To make git run unit tests and lint tests, softlink this file into the
-# .git/hooks directory of the repo you want to test.  The following command will
+# .git/hooks directory of the repo you want to test.  Assuming you have
+# git-hooks checked out into your home directory, the following command will
 # get that done:
-#   ln -s ../../git-hooks/pre-commit .git/hooks/pre-commit
+#   ln -s ${HOME}/git-hooks/pre-commit .git/hooks/pre-commit
 #
-# We expect that the PWD for this code is the root of the repo using git-hooks
-# as a submodule.
+# We expect that the PWD for this code is the root of the repo.
 
 set -e -u -x -o pipefail
 

--- a/pre-commit
+++ b/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This code is intended to be used as in a directory called git-hooks.  It
+# This code is intended to be used in a directory called git-hooks.  It
 # is a language agnostic tester and linter, and should lint, test, and run
 # coverage for any and all languages you happen to use.
 #

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This code is intended to be used as in a directory called git-hooks.
+# This code is intended to be used in a directory called git-hooks.
 
 # prepare-commit-msg is a shell script that gets called by git with the temp
 # filename of the future commit message as its first argument. Its purpose is

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This code is intended to be used as part of a submodule called git-hooks.
+# This code is intended to be used as in a directory called git-hooks.
 
 # prepare-commit-msg is a shell script that gets called by git with the temp
 # filename of the future commit message as its first argument. Its purpose is
@@ -14,11 +14,11 @@
 # append anything to a file.
 #
 # To make git run this script, softlink this file into the .git/hooks
-# directory.  The following command will get that done:
-#   ln -s ../../git-hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
+# directory. Assuming you have git-hooks checked out into your home directory,
+# the following command will get that done:
+#   ln -s ${HOME}/git-hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
 #
-# We expect that the PWD for this code is the root of the repo using git-hooks
-# as a submodule.
+# We expect that the PWD for this code is the root of the repo.
 
 set -e -u -x -o pipefail
 


### PR DESCRIPTION
Using git-hooks as a module usually creates more work than it hides. Instead, we should use it as a source of scripts in a centralized location.  This updates the comments for that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/git-hooks/18)
<!-- Reviewable:end -->
